### PR TITLE
Fixed: Customer's name does not appear on the Billplz payment page when using the "Name" field in the form settings

### DIFF
--- a/billplz.php
+++ b/billplz.php
@@ -3,7 +3,7 @@
 Plugin Name: Billplz for GravityForms
 Plugin URI: https://wordpress.org/plugins/billplz-for-gravityforms/
 Description: Billplz. Fair payment platform.
-Version: 3.9.1
+Version: 3.9.2
 Author: Billplz Sdn Bhd
 Author URI: https://www.billplz.com
 License: GPL-2.0+
@@ -13,7 +13,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || die();
 
-define('GF_BILLPLZ_VERSION', '3.9.1');
+define('GF_BILLPLZ_VERSION', '3.9.2');
 define('GF_BILLPLZ_PLUGIN_FILE',  __FILE__ );
 define('GF_BILLPLZ_PLUGIN_URL', plugin_dir_url(GF_BILLPLZ_PLUGIN_FILE));
 

--- a/class-gf-billplz.php
+++ b/class-gf-billplz.php
@@ -513,9 +513,9 @@ class GFBillplz extends GFPaymentAddOn
         $int_reference_1 = isset($feed_meta[$b.'reference_1']) ? $feed_meta[$b.'reference_1'] : '';
         $int_reference_2 = isset($feed_meta[$b.'reference_2']) ? $feed_meta[$b.'reference_2'] : '';
 
-        $email = isset($entry[$int_email]) ? $entry[$int_email] : '';
-        $mobile = isset($entry[$int_mobile]) ? $entry[$int_mobile] : '';
-        $name = isset($entry[$int_name]) ? $entry[$int_name] : '';
+        $email = $this->get_field_value( $form, $entry, $int_email );
+        $mobile = $this->get_field_value( $form, $entry, $int_mobile );
+        $name = $this->get_field_value( $form, $entry, $int_name );
 
         $parameter = array(
             'collection_id' => trim($feed_meta['collection_id']),

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wanzulnet
 Tags: billplz
 Tested up to: 6.2.2
-Stable tag: 3.9.1
+Stable tag: 3.9.2
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -23,6 +23,9 @@ Install this plugin to accept payment using Billplz.
 * Screenshot 6: Sample entry on administration side.
 
 == Changelog ==
+
+= 3.9.2 =
+* FIXED: Customer's name does not appear on the Billplz payment page when using the "Name" field in the form settings
 
 = 3.9.1 =
 * Based on PayPal Standard Addon 3.5


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Fixes the issue where customer's name does not appear on the Billplz payment page when using the "Name" field in the form settings.